### PR TITLE
feat: use id as default slug | 使用page id 作为默认的slug路径

### DIFF
--- a/lib/notion/getAllPosts.js
+++ b/lib/notion/getAllPosts.js
@@ -53,6 +53,10 @@ export async function getAllPosts({
           : dayjs(block[id].value?.created_time)
       ).valueOf()
 
+      // use id as default slug
+      if (!properties.slug) {
+        properties.slug = properties.id
+      }
       data.push(properties)
     }
 


### PR DESCRIPTION
类似[notion-next](https://github.com/tangly1024/NotionNext)，不填写slug则使用notion page id作为路径